### PR TITLE
Fixed code generation

### DIFF
--- a/plugins/generator-1.15.2/forge-1.15.2/block.definition.yaml
+++ b/plugins/generator-1.15.2/forge-1.15.2/block.definition.yaml
@@ -284,6 +284,6 @@ templates:
 localizationkeys:
   - key: block.@modid.@registryname
     mapto: name
-  - key: block.@modid.@registryname.tooltip.1
-    condition: descriptionLocalized
+  - key: block.@modid.@registryname.tooltip
+    condition: "descriptionLocalized()"
     mapto: specialInfo

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
@@ -1,29 +1,29 @@
 <#--
  # MCreator (https://mcreator.net/)
  # Copyright (C) 2020 Pylo and contributors
- # 
+ #
  # This program is free software: you can redistribute it and/or modify
  # it under the terms of the GNU General Public License as published by
  # the Free Software Foundation, either version 3 of the License, or
  # (at your option) any later version.
- # 
+ #
  # This program is distributed in the hope that it will be useful,
  # but WITHOUT ANY WARRANTY; without even the implied warranty of
  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  # GNU General Public License for more details.
- # 
+ #
  # You should have received a copy of the GNU General Public License
  # along with this program.  If not, see <https://www.gnu.org/licenses/>.
- # 
+ #
  # Additional permission for code generator templates (*.ftl files)
- # 
- # As a special exception, you may create a larger work that contains part or 
- # all of the MCreator code generator templates (*.ftl files) and distribute 
- # that work under terms of your choice, so long as that work isn't itself a 
- # template for code generation. Alternatively, if you modify or redistribute 
- # the template itself, you may (at your option) remove this special exception, 
- # which will cause the template and the resulting code generator output files 
- # to be licensed under the GNU General Public License without this special 
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
  # exception.
 -->
 
@@ -184,18 +184,24 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 		</#if>
 
 		<#if data.specialInfo?has_content>
+		<#if data.descriptionLocalized()>
+		@Override
+		public void addInformation(ItemStack itemstack, IBlockReader world, List list, ITooltipFlag flag) {
+			super.addInformation(itemstack, world, list, flag);
+			<#assign line = 0>
+			<#list data.specialInfo as entry>
+			list.add(new TranslationTextComponent("block.${JavaModName?lower_case?replace("mod", "")}.${name?lower_case}.tooltip${line}"));
+			<#assign line++>
+			</#list>
+		}
+		<#else>
 		@Override @OnlyIn(Dist.CLIENT) public void addInformation(ItemStack itemstack, IBlockReader world, List<ITextComponent> list, ITooltipFlag flag) {
 			super.addInformation(itemstack, world, list, flag);
-			<#if data.descriptionLocalized>
-				<#list data.specialInfo as entry>
-				list.add(new TranslationTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
-				</#list>
-			<#else>
-				<#list data.specialInfo as entry>
-				list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
-				</#list>
-			</#if>
+			<#list data.specialInfo as entry>
+			list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+			</#list>
 		}
+		</#if>
 		</#if>
 
 		<#if data.emissiveRendering>
@@ -396,7 +402,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
         @Override public IFluidState getFluidState(BlockState state) {
             return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : super.getFluidState(state);
         }
-	
+
 		@Override public BlockState updatePostPlacement(BlockState state, Direction facing, BlockState facingState, IWorld world, BlockPos currentPos, BlockPos facingPos) {
 	        if (state.get(WATERLOGGED)) {
 		        world.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(world));
@@ -693,7 +699,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 			@Override public boolean hasTileEntity(BlockState state) {
 				return true;
 			}
-			
+
 			@Override public TileEntity createTileEntity(BlockState state, IBlockReader world) {
     		    return new CustomTileEntity();
     		}
@@ -713,7 +719,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
    			         InventoryHelper.dropInventoryItems(world, pos, (CustomTileEntity) tileentity);
    			         world.updateComparatorOutputLevel(pos, this);
    			      }
-			
+
    			      super.onReplaced(state, world, pos, newState, isMoving);
    			   }
    			}

--- a/plugins/mcreator-localization/help/default/item/description_localized.md
+++ b/plugins/mcreator-localization/help/default/item/description_localized.md
@@ -1,5 +1,3 @@
-If you put a translation key in the field above.
+If you check this box, the text in the field above will be localized (and able to be translated)
 
 It will automatically be added to the translation tab.
-
-Advised format: element.name.description (example: block.furnace.description)

--- a/plugins/mcreator-localization/help/fr_FR/item/description_localized.md
+++ b/plugins/mcreator-localization/help/fr_FR/item/description_localized.md
@@ -1,5 +1,3 @@
-Si vous mettez une clef de traduction dans le champ au dessus.
+Si vous cochez la boite, le texte dans le champ au dessus sera localisé (et donc traduisible)
 
-Sera automatiquement ajouté à la l'onglet de traduction.
-
-Format conseillé: element.nom.description (exemple: block.four.description)
+Il sera automatiquement ajouté à la l'onglet de traduction.

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -184,6 +184,10 @@ import java.util.Map;
 		return renderType;
 	}
 
+	public boolean descriptionLocalized(){
+		return descriptionLocalized;
+	}
+
 	public boolean hasCustomDrop() {
 		return !customDrop.isEmpty();
 	}

--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -392,17 +392,28 @@ public class Generator implements Closeable {
 						.replace("@modid", workspace.getWorkspaceSettings().getModID())
 						.replace("@registryname", element.getModElement().getRegistryName()));
 				try {
-					String value = (String) element.getClass().getField(mapto.trim()).get(element);
+					int i = 0;
+					for(String value : element.getClass().getField(mapto.trim()).get(element).toString().split(",")){
+						List<String> list = Arrays
+								.asList(element.getClass().getField(mapto.trim()).get(element).toString().split(","));
+						value = list.get(i);
+						if(!value.isEmpty()) {
+							String suffix = (String) ((Map<?, ?>) template).get("suffix");
+							if (suffix != null)
+								value += suffix;
 
-					String suffix = (String) ((Map<?, ?>) template).get("suffix");
-					if (suffix != null)
-						value += suffix;
+							String prefix = (String) ((Map<?, ?>) template).get("prefix");
+							if (prefix != null)
+								value = prefix + value;
+							if (value != null && !value.equals("[]")) {
+								key = key + i;
+								workspace.setLocalization(key, value);
+								i++;
+							}
+						}
+					}
 
-					String prefix = (String) ((Map<?, ?>) template).get("prefix");
-					if (prefix != null)
-						value = prefix + value;
 
-					workspace.setLocalization(key, value);
 				} catch (IllegalAccessException | NoSuchFieldException e) {
 					LOG.error(e.getMessage(), e);
 					LOG.error("[" + generatorName + "] " + e.getMessage());


### PR DESCRIPTION
I fixed the code generation for Forge 1.15.2, but keys and translations still have problems.
1. New keys (for tooltips only) have key.tooltip0 then, key.tooltip01 then, key.tooltip012, etc.
2. The first line has [ at the beginning, and the last line has ] at the end.
3. Except for the first line, all lines have a space at the beginning.

Anyways, i hope it will help you :)