### PR TITLE
Clearer POI validation code

### DIFF
--- a/src/main/java/net/mcreator/minecraft/ElementUtil.java
+++ b/src/main/java/net/mcreator/minecraft/ElementUtil.java
@@ -20,7 +20,6 @@
 package net.mcreator.minecraft;
 
 import net.mcreator.element.BaseType;
-import net.mcreator.element.GeneratableElement;
 import net.mcreator.element.ModElementType;
 import net.mcreator.element.parts.MItemBlock;
 import net.mcreator.element.types.interfaces.IPOIProvider;
@@ -229,21 +228,15 @@ public class ElementUtil {
 	 * Returns list of blocks attached to a POI for this workspace
 	 *
 	 * @param workspace Workspace to return for
-	 * @param elementToSkip If not null, this ME will be skipped and its POI will not be added to the list
 	 * @return List of blocks attached to a POI for this workspace
 	 */
-	public static List<MItemBlock> loadAllPOIBlocks(Workspace workspace, @Nullable ModElement elementToSkip) {
+	public static List<MItemBlock> loadAllPOIBlocks(Workspace workspace) {
 		List<MItemBlock> elements = loadBlocks(workspace).stream().filter(MCItem::isPOI)
 				.map(e -> new MItemBlock(workspace, e.getName())).collect(Collectors.toList());
 
 		for (ModElement modElement : workspace.getModElements()) {
-			if (modElement.equals(elementToSkip))
-				continue;
-
-			GeneratableElement ge = modElement.getGeneratableElement();
-			if (ge instanceof IPOIProvider poiProvider) {
+			if (modElement.getGeneratableElement() instanceof IPOIProvider poiProvider)
 				elements.addAll(poiProvider.poiBlocks());
-			}
 		}
 
 		return elements;

--- a/src/main/java/net/mcreator/ui/modgui/VillagerProfessionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/VillagerProfessionGUI.java
@@ -21,7 +21,9 @@ package net.mcreator.ui.modgui;
 
 import net.mcreator.element.parts.MItemBlock;
 import net.mcreator.element.types.VillagerProfession;
+import net.mcreator.minecraft.DataListEntry;
 import net.mcreator.minecraft.ElementUtil;
+import net.mcreator.minecraft.MCItem;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.SearchableComboBox;
 import net.mcreator.ui.component.util.ComboBoxUtil;
@@ -139,10 +141,13 @@ public class VillagerProfessionGUI extends ModElementGUI<VillagerProfession> {
 		displayName.setValidator(new TextFieldValidator(displayName,
 				L10N.t("elementgui.villager_profession.profession_needs_display_name")));
 		displayName.enableRealtimeValidation();
-		pointOfInterest.setValidator(new UniqueNameValidator(L10N.t("elementgui.villager_profession.profession_block_validator"),
-				() -> pointOfInterest.getBlock().getUnmappedValue(),
-				() -> ElementUtil.loadAllPOIBlocks(mcreator.getWorkspace(), getModElement()).stream()
-						.map(MItemBlock::getUnmappedValue), null).setIsPresentOnList(false));
+		pointOfInterest.setValidator(
+				new UniqueNameValidator(L10N.t("elementgui.villager_profession.profession_block_validator"),
+						() -> pointOfInterest.getBlock().getUnmappedValue(),
+						() -> ElementUtil.loadAllPOIBlocks(mcreator.getWorkspace()).stream()
+								.map(MItemBlock::getUnmappedValue),
+						ElementUtil.loadBlocks(mcreator.getWorkspace()).stream().filter(MCItem::isPOI)
+								.map(DataListEntry::getName).toList(), null).setIsPresentOnList(isEditingMode()));
 		actionSound.getVTextField().setValidator(new TextFieldValidator(actionSound.getVTextField(),
 				L10N.t("elementgui.common.error_sound_empty_null")));
 		professionTextureFile.setValidator(() -> {

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -1551,7 +1551,7 @@ public class TestWorkspaceDataProvider {
 		} else if (ModElementType.VILLAGERPROFESSION.equals(modElement.getType())) {
 			VillagerProfession profession = new VillagerProfession(modElement);
 			profession.displayName = modElement.getName();
-			List<MItemBlock> poiBlocks = ElementUtil.loadAllPOIBlocks(modElement.getWorkspace(), null);
+			List<MItemBlock> poiBlocks = ElementUtil.loadAllPOIBlocks(modElement.getWorkspace());
 			profession.pointOfInterest = new MItemBlock(modElement.getWorkspace(), getRandomMCItem(random,
 					blocks.stream()
 							.filter(e -> !poiBlocks.contains(new MItemBlock(modElement.getWorkspace(), e.getName())))


### PR DESCRIPTION
The `elementToSkip` of the new method added to `ElementUtil` in MCreator#2630 seemed confusing to me, so I changed the method to use features provided by `UniqueNameValidator` instead of using an extra hardcoded method parameter.